### PR TITLE
Fix _endGesture call in SwipeTracker40.js

### DIFF
--- a/src/v40/SwipeTracker40.js
+++ b/src/v40/SwipeTracker40.js
@@ -101,7 +101,7 @@ class SwipeTracker40Class extends SwipeTracker {
 
       const isTouchpad = (device === DeviceType.TOUCHPAD);
 
-      this._endGesture(this, time, distance, isTouchpad);
+      this._endGesture(time, distance, isTouchpad);
     }
   }
 


### PR DESCRIPTION
Hi there! I just received [this bug report](https://github.com/Schneegans/Desktop-Cube/issues/140) for the Desktop Cube. And I think that the issue is caused by an erroneous call to `this._endGesture()` in the `SwipeTracker40`.

This method [does not take the gesture](https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/swipeTracker.js?ref_type=heads#L711) as first parameter. If I remove the `this` parameter, the Desktop Cube works again with X11 gestures :smile:.