### PR TITLE
Fix unhook function if obj._toucheggTracker is undefined

### DIFF
--- a/src/v40/EntryPoint40.js
+++ b/src/v40/EntryPoint40.js
@@ -164,6 +164,8 @@ class EntryPoint40Class extends GObject.Object {
 
   static unhook(obj) {
     /* eslint-disable no-underscore-dangle, no-param-reassign */
+    if (!obj._toucheggTracker)
+      return;
     obj._toucheggTracker.disconnect(obj._toucheggBegin);
     obj._toucheggTracker.disconnect(obj._toucheggUpdate);
     obj._toucheggTracker.disconnect(obj._toucheggEnd);


### PR DESCRIPTION
This fixes the "obj._toucheggTracker is undefined" error. This can happen if the extension is run under Wayland as obj._toucheggTracker is not initialized when the extension is enabled however it still tries to unhook it when disabling the extension.

May fix issue #57