### PR TITLE
Support for shell version 47

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,6 +6,7 @@
   "url": "https://github.com/JoseExposito/gnome-shell-extension-x11gestures",
   "shell-version": [
     "45",
-    "46"
+    "46",
+    "47"
   ]
 }


### PR DESCRIPTION
As in #62, I would also like the support of this nice extension on gnome shell version 47.
I have never developed or tweaked shell extensions, but on my PC i just updated the ``metadata.json`` file to include gnome shell version 47, and it works.

I don't know if I have to look out for something else, but this is a quick-fix to have back the extension working.